### PR TITLE
Consolidating Job Managers

### DIFF
--- a/src/EphIt/EphIt.Service/Posh/Job/IPoshJobManager.cs
+++ b/src/EphIt/EphIt.Service/Posh/Job/IPoshJobManager.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace EphIt.Service.Posh.Job
 {
-    public interface IJobManager
+    public interface IPoshJobManager
     {
         public void QueueJob(PoshJob pSJob);
         public PoshJob DequeueJob();

--- a/src/EphIt/EphIt.Service/Posh/Job/PoshJobManager.cs
+++ b/src/EphIt/EphIt.Service/Posh/Job/PoshJobManager.cs
@@ -10,10 +10,11 @@ using EphIt.Service.Posh;
 using System.Management.Automation;
 using System.Linq;
 using Serilog;
+using EphIt.BL.JobManager;
 
 namespace EphIt.Service.Posh.Job
 {
-    public class JobManager : IJobManager
+    public class PoshJobManager : IPoshJobManager
     {
         private ConcurrentQueue<PoshJob> jobQueue = new ConcurrentQueue<PoshJob>();
         private ConcurrentQueue<ProblemJob> problemJobs = new ConcurrentQueue<ProblemJob>();
@@ -21,9 +22,10 @@ namespace EphIt.Service.Posh.Job
         private ConcurrentQueue<Task<PSDataCollection<PSObject>>> runningJobs = new ConcurrentQueue<Task<PSDataCollection<PSObject>>>();
         private IPoshManager _poshManager;
         private IStreamHelper _streamHelper;
-
-        public JobManager(IPoshManager runspaceManager, IStreamHelper streamHelper)
+        private IJobManager _jobManager;
+        public PoshJobManager(IPoshManager runspaceManager, IStreamHelper streamHelper, IJobManager jobManager)
         {
+            _jobManager = jobManager;
             _poshManager = runspaceManager;
             _streamHelper = streamHelper;
         }
@@ -56,6 +58,7 @@ namespace EphIt.Service.Posh.Job
         }
         public void StartPendingJob()
         {   
+            
             if(!HasPendingJob())
             {
                 return;

--- a/src/EphIt/EphIt.Service/Program.cs
+++ b/src/EphIt/EphIt.Service/Program.cs
@@ -16,6 +16,7 @@ using EphIt.Service.Posh.Job;
 using EphIt.Service.Posh;
 using EphIt.Service.Posh.Stream;
 using EphIt.Service.Workers;
+using EphIt.BL.JobManager;
 
 namespace EphIt.Service
 {
@@ -60,6 +61,7 @@ namespace EphIt.Service
                 {
                     services.AddSingleton<IStreamHelper, StreamHelper>();
                     services.AddSingleton<IPoshManager, PoshManager>();
+                    services.AddSingleton<IPoshJobManager, PoshJobManager>();
                     services.AddSingleton<IJobManager, JobManager>();
                     services.AddDbContext<EphItContext>(
                         options =>

--- a/src/EphIt/EphIt.Service/Workers/StartPendingJobsWorker.cs
+++ b/src/EphIt/EphIt.Service/Workers/StartPendingJobsWorker.cs
@@ -13,11 +13,11 @@ namespace EphIt.Service.Workers
     public class StartPendingJobsWorker : BackgroundService
     {
         private readonly ILogger<StartPendingJobsWorker> _logger;
-        private IJobManager _jobManager;
-        public StartPendingJobsWorker(ILogger<StartPendingJobsWorker> logger, IJobManager jobManager)
+        private IPoshJobManager _poshJobManager;
+        public StartPendingJobsWorker(ILogger<StartPendingJobsWorker> logger, IPoshJobManager poshJobManager)
         {
             _logger = logger;
-            _jobManager = jobManager;
+            _poshJobManager = poshJobManager;
         }
 
         public override Task StartAsync(CancellationToken cancellationToken)
@@ -43,7 +43,7 @@ namespace EphIt.Service.Workers
             while (!stoppingToken.IsCancellationRequested)
             {
                 _logger.LogInformation("Worker running at: {time}", DateTimeOffset.Now);
-                _jobManager.StartPendingJob();
+                _poshJobManager.StartPendingJob();
                 await Task.Delay(1000, stoppingToken);
             }
         }


### PR DESCRIPTION
I created a JobManager with a rough "vision" for how I see what you did hooking into the rest of the solution.

Basically the thought is a Job can be any type of script supported (not just powerShell though only Posh will be supported v1).

So what you created was really a PowerShellJobManager, not a JobManager so I updated some class names to make that more known. I also created a job manager earlier and injected it into the service so you can consume it. It has a few methods on it letting you get a job, update the status of a job, and log output to the database.

You can use it with this:

```
            var job = _jobManager.GetQueuedJob(Db.Models.ScriptLanguageEnum.PowerShellCore);
            if(job != null)
            {
                _jobManager.Start(job);
                // Logic to run job
                // sample logging:
                await _jobManager.LogAsync(job.JobUid, "My Message", Db.Enums.JobLogLevelEnum.Information);
                _jobManager.Finish(job);

            }
```

GetQueuedJob accepts a parameter of "Supported Types" where you can send all the types you support. So for instance if your service can run jobs of type SQL and PowerShellCore, you'd send

```
Db.Models.ScriptLanguageEnum.PowerShellCore | Db.Models.ScriptLanguageEnum.SQL
```

And GetQueuedJob will always return 1 job that needs to run that fits one of the provided types. So if you said you can run SQL or PowerShell, it'll return a sql job or a Posh job (or null if nothing is ready to run).

_jobManager has methods for Start and Finish (which will set the start and stop times, finish accepts a bool also to say if it errored) and also has methods for logging async. LogLevel lines up with PowerShell streams nicely. 

Only thing that might need to change is Start() and Finish() currently accept a Job object - we might want to update that to accept the JobUID and have it re-get the Job before setting the Db times.  Since threading is occurring the change tracker might not be able to track Job from start to finish.