### PR TITLE
removed runspaces, fixed posh job thread

### DIFF
--- a/src/EphIt/EphIt.Server/EphIt.Server.csproj
+++ b/src/EphIt/EphIt.Server/EphIt.Server.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>

--- a/src/EphIt/EphIt.Service.Tests/JobQueueTests.cs
+++ b/src/EphIt/EphIt.Service.Tests/JobQueueTests.cs
@@ -33,7 +33,7 @@ namespace EphIt.Service.Tests
             ephItContext = new EphItContext();
             logger = new Mock<ILogger<EphIt.BL.JobManager.JobManager>>();
             jobManager = new EphIt.BL.JobManager.JobManager(ephItContext, logger.Object);
-            poshJobManager = new PoshJobManager(poshManager, realStream);
+            poshJobManager = new PoshJobManager(poshManager);
             job = new PoshJob();
             job.Script = "$VerbosePreference = 'Continue'; Get-Module; Write-Verbose '123'; write-debug '123'; write-error '123'; start-sleep 300";
         }
@@ -46,7 +46,7 @@ namespace EphIt.Service.Tests
         {
             bool hasJob = poshJobManager.HasPendingJob();
             Assert.IsFalse(hasJob);
-            poshJobManager.QueueJob(job);
+            poshJobManager.QueuePendingJob(job);
             hasJob = poshJobManager.HasPendingJob();
             Assert.IsTrue(hasJob);
         }
@@ -56,7 +56,7 @@ namespace EphIt.Service.Tests
         {
             bool hasJob = poshJobManager.HasPendingJob();
             Assert.IsFalse(hasJob);
-            poshJobManager.QueueJob(this.job);
+            poshJobManager.QueuePendingJob(this.job);
             hasJob = poshJobManager.HasPendingJob();
             Assert.IsTrue(hasJob);
 
@@ -64,7 +64,7 @@ namespace EphIt.Service.Tests
             PoshJob job = null;  
             if (hasJob)
             {
-                job = poshJobManager.DequeueJob();
+                job = poshJobManager.DequeuePendingJob();
             }
             Assert.IsNotNull(job);
             hasJob = poshJobManager.HasPendingJob();
@@ -75,7 +75,7 @@ namespace EphIt.Service.Tests
         {
             bool hasJob = poshJobManager.HasPendingJob();
             Assert.IsFalse(hasJob);
-            poshJobManager.QueueJob(this.job);
+            poshJobManager.QueuePendingJob(this.job);
             hasJob = poshJobManager.HasPendingJob();
             Assert.IsTrue(hasJob);
 
@@ -85,7 +85,7 @@ namespace EphIt.Service.Tests
         }
         private void StartJob()
         {
-            poshJobManager.QueueJob(this.job);
+            poshJobManager.QueuePendingJob(this.job);
             poshJobManager.StartPendingJob();
         }
         /* unsure how to test this

--- a/src/EphIt/EphIt.Service.Tests/JobQueueTests.cs
+++ b/src/EphIt/EphIt.Service.Tests/JobQueueTests.cs
@@ -7,6 +7,10 @@ using EphIt.BL.JobManager;
 using EphIt.Db.Models;
 using Microsoft.Extensions.Logging;
 using System.Security.Cryptography;
+using System.Management.Automation;
+using EphIt.BL.Script;
+using EphIt.BL.User;
+using System.Threading;
 
 namespace EphIt.Service.Tests
 {
@@ -16,20 +20,22 @@ namespace EphIt.Service.Tests
         private Mock<IStreamHelper> streamMoq;
         private IPoshManager poshManager;
         private EphItContext ephItContext;
-        private Mock<ILogger<JobManager>> logger;
+        private Mock<ILogger<EphIt.BL.JobManager.JobManager>> logger;
         private IJobManager jobManager;
         private IPoshJobManager poshJobManager;
         private PoshJob job;
         private void setup()
         {
             streamMoq = new Mock<IStreamHelper>();
-            poshManager = new PoshManager(streamMoq.Object);
+            streamMoq.Setup(s => s.RecordStream(It.IsAny<PoshJob>(), It.IsAny<object>() ,It.IsAny<DataAddedEventArgs>()));
+            IStreamHelper realStream = new StreamHelper();
+            poshManager = new PoshManager(realStream);
             ephItContext = new EphItContext();
-            logger = new Mock<ILogger<JobManager>>();
-            jobManager = new JobManager(ephItContext, logger.Object);
-            poshJobManager = new PoshJobManager(poshManager, streamMoq.Object, jobManager);
+            logger = new Mock<ILogger<EphIt.BL.JobManager.JobManager>>();
+            jobManager = new EphIt.BL.JobManager.JobManager(ephItContext, logger.Object);
+            poshJobManager = new PoshJobManager(poshManager, realStream);
             job = new PoshJob();
-            job.Script = "Get-Module; write-Verbose '123'";
+            job.Script = "$VerbosePreference = 'Continue'; Get-Module; Write-Verbose '123'; write-debug '123'; write-error '123'; start-sleep 300";
         }
         public JobQueueTests()
         {
@@ -75,8 +81,21 @@ namespace EphIt.Service.Tests
 
             //the runspace needs to have commands added.
             //bug must be fixed.
-            //poshJobManager.StartPendingJob();
-
+            poshJobManager.StartPendingJob();
         }
+        private void StartJob()
+        {
+            poshJobManager.QueueJob(this.job);
+            poshJobManager.StartPendingJob();
+        }
+        /* unsure how to test this
+        [TestMethod]
+        public void ShouldRecordVerboseLog()
+        {
+            StartJob();
+            Thread.Sleep(2000);
+            streamMoq.Verify(m => m.RecordStream(It.IsAny<PoshJob>(), It.IsAny<object>(), It.IsAny<DataAddedEventArgs>()), Times.Once);
+        }
+        */
     }
 }

--- a/src/EphIt/EphIt.Service/Posh/IPoshManager.cs
+++ b/src/EphIt/EphIt.Service/Posh/IPoshManager.cs
@@ -12,7 +12,13 @@ namespace EphIt.Service.Posh
         public Runspace GetRunspace();
         public void RetireRunspace(Runspace runspace);
         public int GetNumberOfRemainingRunspaces();
-        public Task<PSDataCollection<PSObject>> RunJob(PoshJob poshJob);
+        public PoshJob RunJob(PoshJob poshJob);
         public bool RunspaceAvailable();
+        public PowerShell NewPowerShell();
+        public PowerShell GetPowerShell();
+        public void RetirePowerShell(PowerShell powershell);
+        public int GetNumberOfRemainingPowerShell();
+
+
     }
 }

--- a/src/EphIt/EphIt.Service/Posh/Job/IPoshJobManager.cs
+++ b/src/EphIt/EphIt.Service/Posh/Job/IPoshJobManager.cs
@@ -9,8 +9,8 @@ namespace EphIt.Service.Posh.Job
 {
     public interface IPoshJobManager
     {
-        public void QueueJob(PoshJob pSJob);
-        public PoshJob DequeueJob();
+        public void QueuePendingJob(PoshJob pSJob);
+        public PoshJob DequeuePendingJob();
         public bool HasPendingJob();
         public void StartPendingJob();
         public void ProcessRunningJobs();

--- a/src/EphIt/EphIt.Service/Posh/Job/PoshJobManager.cs
+++ b/src/EphIt/EphIt.Service/Posh/Job/PoshJobManager.cs
@@ -22,10 +22,10 @@ namespace EphIt.Service.Posh.Job
         private ConcurrentQueue<Task<PSDataCollection<PSObject>>> runningJobs = new ConcurrentQueue<Task<PSDataCollection<PSObject>>>();
         private IPoshManager _poshManager;
         private IStreamHelper _streamHelper;
-        private IJobManager _jobManager;
-        public PoshJobManager(IPoshManager poshManager, IStreamHelper streamHelper, IJobManager jobManager)
+        //private EphIt.BL.JobManager.IJobManager _jobManager;
+        public PoshJobManager(IPoshManager poshManager, IStreamHelper streamHelper)
         {
-            _jobManager = jobManager;
+            //_jobManager = jobManager;
             _poshManager = poshManager;
             _streamHelper = streamHelper;
         }
@@ -33,6 +33,8 @@ namespace EphIt.Service.Posh.Job
         {
             foreach(var job in runningJobs)
             {
+                var status = job.Status;
+                var x= job.Result;
                 //record any more output
                 //done?  record end date, remove from list
                 //error?

--- a/src/EphIt/EphIt.Service/Posh/Job/PoshJobManager.cs
+++ b/src/EphIt/EphIt.Service/Posh/Job/PoshJobManager.cs
@@ -16,38 +16,63 @@ namespace EphIt.Service.Posh.Job
 {
     public class PoshJobManager : IPoshJobManager
     {
-        private ConcurrentQueue<PoshJob> jobQueue = new ConcurrentQueue<PoshJob>();
+        private ConcurrentQueue<PoshJob> pendingJobQueue = new ConcurrentQueue<PoshJob>();
         private ConcurrentQueue<ProblemJob> problemJobs = new ConcurrentQueue<ProblemJob>();
         private ConcurrentQueue<PoshJob> retryJobs = new ConcurrentQueue<PoshJob>();
-        private ConcurrentQueue<Task<PSDataCollection<PSObject>>> runningJobs = new ConcurrentQueue<Task<PSDataCollection<PSObject>>>();
+        private ConcurrentDictionary<Guid, PoshJob> runningJobs = new ConcurrentDictionary<Guid, PoshJob>();
         private IPoshManager _poshManager;
-        private IStreamHelper _streamHelper;
         //private EphIt.BL.JobManager.IJobManager _jobManager;
-        public PoshJobManager(IPoshManager poshManager, IStreamHelper streamHelper)
+        public PoshJobManager(IPoshManager poshManager)
         {
             //_jobManager = jobManager;
             _poshManager = poshManager;
-            _streamHelper = streamHelper;
         }
         public void ProcessRunningJobs()
         {
-            foreach(var job in runningJobs)
+            foreach(var runningJob in runningJobs)
             {
-                var status = job.Status;
-                var x= job.Result;
+                var jobTask = runningJob.Value.RunningJob;
+                var poshInstance = runningJob.Value.PoshInstance;
+                if(jobTask.Status == TaskStatus.RanToCompletion)
+                {
+                    _poshManager.RetirePowerShell(poshInstance);
+                    RemoveRunningJob(runningJob);
+                }
                 //record any more output
                 //done?  record end date, remove from list
                 //error?
             }
         }
-        public void QueueJob(PoshJob job)
-        {
-            jobQueue.Enqueue(job);
-        }
-        public PoshJob DequeueJob()
+        public void RemoveRunningJob(KeyValuePair<Guid, PoshJob> runningJob)
         {
             PoshJob result;
-            jobQueue.TryDequeue(out result);
+            runningJobs.Remove(runningJob.Key, out result);
+            if (result == null) //cound not remove.  Is it already gone?
+            {
+                runningJobs.TryGetValue(runningJob.Key, out result);
+            }
+            else
+            {
+                return;
+            }
+            if (result != null) //its still there
+            {
+                runningJobs.Remove(runningJob.Key, out result);
+            }
+            if (result == null) //could not remove
+            {
+                //i dont know what to do here.
+            }
+            return;
+        }
+        public void QueuePendingJob(PoshJob job)
+        {
+            pendingJobQueue.Enqueue(job);
+        }
+        public PoshJob DequeuePendingJob()
+        {
+            PoshJob result;
+            pendingJobQueue.TryDequeue(out result);
             if (result == null)
             {
                 return null;
@@ -56,7 +81,7 @@ namespace EphIt.Service.Posh.Job
         }
         public bool HasPendingJob()
         {
-            return !jobQueue.IsEmpty;
+            return !pendingJobQueue.IsEmpty;
         }
         public void StartPendingJob()
         {   
@@ -65,26 +90,31 @@ namespace EphIt.Service.Posh.Job
             {
                 return;
             }
-            if(!_poshManager.RunspaceAvailable())
+            /*if(!_poshManager.RunspaceAvailable())
             {
                 return;
-            }
+            }*/
             PoshJob pendingJob;
-            jobQueue.TryDequeue(out pendingJob);
+            pendingJobQueue.TryDequeue(out pendingJob);
             if(pendingJob == null)
             {
                 return;
             }
             try
             {
-                var runningJob = _poshManager.RunJob(pendingJob);
+                PoshJob runningJob = _poshManager.RunJob(pendingJob);
                 if (runningJob == null)
                 {
                     retryJobs.Enqueue(pendingJob);
                 }
                 else
                 {
-                    runningJobs.Enqueue(runningJob);
+                    bool success = runningJobs.TryAdd(Guid.NewGuid(), runningJob);
+                    if(!success) 
+                    {
+                        //this is bad and hopefully never happens.
+                        Log.Error("Unable to queue the running job, this job will not be monitored.");
+                    }
                 }
             }
             catch (Exception e)

--- a/src/EphIt/EphIt.Service/Posh/Stream/StreamHelper.cs
+++ b/src/EphIt/EphIt.Service/Posh/Stream/StreamHelper.cs
@@ -4,6 +4,24 @@ namespace EphIt.Service.Posh.Stream {
     public class StreamHelper : IStreamHelper {
         public void RecordStream(PoshJob poshJob, object sender, DataAddedEventArgs e) {
             //todo implement this.
+            var type = sender.GetType();
+            
+            if (type == typeof(PSDataCollection<VerboseRecord>))
+            {
+                VerboseRecord record = ((PSDataCollection<VerboseRecord>)sender)[e.Index];
+            }
+            if (type == typeof(PSDataCollection<DebugRecord>))
+            {
+                DebugRecord record = ((PSDataCollection<DebugRecord>)sender)[e.Index];
+            }
+            if (type == typeof(PSDataCollection<ErrorRecord>))
+            {
+                ErrorRecord record = ((PSDataCollection<ErrorRecord>)sender)[e.Index];
+            }
+            if (type == typeof(PSDataCollection<WarningRecord>))
+            {
+                WarningRecord record = ((PSDataCollection<WarningRecord>)sender)[e.Index];
+            }
         }
     }
 }

--- a/src/EphIt/EphIt.Service/PoshJob.cs
+++ b/src/EphIt/EphIt.Service/PoshJob.cs
@@ -1,12 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading.Tasks;
+using System.Management.Automation;
 
 namespace EphIt.Service
 {
     public class PoshJob
     {
         public string Script { get; set; }
-        public List<Object> Parameters { get; set; }
+        public Dictionary<string, object> Parameters { get; set; }
+        public Task<PSDataCollection<PSObject>> RunningJob { get; set; }
+        public PowerShell PoshInstance { get; set; }
     }
 }

--- a/src/EphIt/EphIt.Service/Program.cs
+++ b/src/EphIt/EphIt.Service/Program.cs
@@ -62,13 +62,14 @@ namespace EphIt.Service
                     services.AddSingleton<IStreamHelper, StreamHelper>();
                     services.AddSingleton<IPoshManager, PoshManager>();
                     services.AddSingleton<IPoshJobManager, PoshJobManager>();
-                    services.AddSingleton<IJobManager, JobManager>();
+                    services.AddScoped<IJobManager, JobManager>();
                     services.AddDbContext<EphItContext>(
                         options =>
                             options.UseSqlServer(hostContext.Configuration.GetConnectionString("EphItDb"))
                         );
                     services.AddHostedService<StartPendingJobsWorker>();
                     services.AddHostedService<MonitorRunningJobsWorker>();
+                    //services.AddHostedService<CreateJobsWorker>();
                 })
             .UseSerilog();
     }

--- a/src/EphIt/EphIt.Service/Workers/CreateJobsWorker.cs
+++ b/src/EphIt/EphIt.Service/Workers/CreateJobsWorker.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using EphIt.Service.Posh.Job;
+using EphIt.Db.Models;
 
 
 //this is debug stuff
@@ -46,11 +47,31 @@ namespace EphIt.Service.Workers
             {
                 _logger.LogInformation("Monitor Running Jobs at: {time}", DateTimeOffset.Now);
                 PoshJob job1 = new PoshJob();
-                job1.Script = "$verbosePreference = 'continue'; Write-Verbose '123'; Write-Error '123'";
-                _poshJobManager.QueueJob(job1);
-                await Task.Delay(20000, stoppingToken);
+                job1.Script = TestScript;
+                Dictionary<string, object> parameters = new Dictionary<string, object>();
+                parameters.Add("stringParam", "stringValue");
+                parameters.Add("intParam", 1);
+                job1.Parameters = parameters;
+                _poshJobManager.QueuePendingJob(job1);
+                await Task.Delay(10000, stoppingToken);
             }
         }
+        private string TestScript = @"
+param(
+    [string]$stringParam,
+    [int]$intParam
+)
+$VerbosePreference = continue
+Write-Verbose -Message 'Verbose Output'
+Write-Debug -Message 'Debug Output'
+Write-Warning -Message 'Warning Output'
+Write-Error -Message 'Error Output'
+Write-Host -Object 'Host Output'
+Write-Output -InputObject 'Output object'
+Write-Output -InputObject([guid]::NewGuid());
+Start-Sleep -Seconds 300            
+";
     }
+    
 }
 

--- a/src/EphIt/EphIt.Service/Workers/CreateJobsWorker.cs
+++ b/src/EphIt/EphIt.Service/Workers/CreateJobsWorker.cs
@@ -1,28 +1,30 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Management.Automation.Runspaces;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using EphIt.Service.Posh.Job;
 
+
+//this is debug stuff
 namespace EphIt.Service.Workers
 {
-    public class StartPendingJobsWorker : BackgroundService
+    class CreateJobsWorker : BackgroundService
     {
         private readonly ILogger<StartPendingJobsWorker> _logger;
         private IPoshJobManager _poshJobManager;
-        public StartPendingJobsWorker(ILogger<StartPendingJobsWorker> logger, IPoshJobManager poshJobManager)
+
+        public CreateJobsWorker(ILogger<StartPendingJobsWorker> logger, IPoshJobManager poshJobManager)
         {
-            _logger = logger;
             _poshJobManager = poshJobManager;
+            _logger = logger;
         }
 
         public override Task StartAsync(CancellationToken cancellationToken)
         {
-            _logger.LogInformation("Service Starting");            
+            _logger.LogInformation("Service Starting");
             return base.StartAsync(cancellationToken);
         }
 
@@ -42,10 +44,13 @@ namespace EphIt.Service.Workers
         {
             while (!stoppingToken.IsCancellationRequested)
             {
-                _logger.LogInformation("Starting Pending Jobs running at: {time}", DateTimeOffset.Now);
-                _poshJobManager.StartPendingJob();
-                await Task.Delay(10000, stoppingToken);
+                _logger.LogInformation("Monitor Running Jobs at: {time}", DateTimeOffset.Now);
+                PoshJob job1 = new PoshJob();
+                job1.Script = "$verbosePreference = 'continue'; Write-Verbose '123'; Write-Error '123'";
+                _poshJobManager.QueueJob(job1);
+                await Task.Delay(20000, stoppingToken);
             }
         }
     }
 }
+

--- a/src/EphIt/EphIt.Service/Workers/MonitorRunningJobsWorker.cs
+++ b/src/EphIt/EphIt.Service/Workers/MonitorRunningJobsWorker.cs
@@ -14,11 +14,11 @@ namespace EphIt.Service.Workers
     class MonitorRunningJobsWorker : BackgroundService
     {
         private readonly ILogger<StartPendingJobsWorker> _logger;
-        private IPoshManager _poshManager;
+        private IPoshJobManager _poshJobManager;
 
-        public MonitorRunningJobsWorker(ILogger<StartPendingJobsWorker> logger, IPoshManager poshManager)
+        public MonitorRunningJobsWorker(ILogger<StartPendingJobsWorker> logger, IPoshJobManager poshJobManager)
         {
-            _poshManager = poshManager;
+            _poshJobManager = poshJobManager;
             _logger = logger;
         }
 
@@ -44,9 +44,9 @@ namespace EphIt.Service.Workers
         {
             while (!stoppingToken.IsCancellationRequested)
             {
-                _logger.LogInformation("Worker running at: {time}", DateTimeOffset.Now);
-                //do work here
-                await Task.Delay(1000, stoppingToken);
+                _logger.LogInformation("Monitor Running Jobs at: {time}", DateTimeOffset.Now);
+                _poshJobManager.ProcessRunningJobs();
+                await Task.Delay(2000, stoppingToken);
             }
         }
     }


### PR DESCRIPTION
The JobManager can't be scoped as a singleton because it has a db context in it's constructor.  This interface can be used in the project, just not from a singleton scoped object.  This can be coded for later when the we tie the job status \ streams back to the Server.

Removed the runspaces from the PoshManager..  This might be added back later if needed.

Improved the stream helper a little bit to break down each incoming stream type.


