### PR TITLE
Adding Role Audits

### DIFF
--- a/src/EphIt/Classlibraries/EphIt.Db/CreateMigrations.ps1
+++ b/src/EphIt/Classlibraries/EphIt.Db/CreateMigrations.ps1
@@ -5,7 +5,7 @@ Param(
 
 Push-Location $PSScriptRoot
 
-#dotnet ef migrations add $MigrationName --startup-project ..\..\EphIt.Server
+dotnet ef migrations add $MigrationName --startup-project ..\..\EphIt.Server
 
 if(-not $IncludeSqlFolderUpdates){
     Pop-Location
@@ -18,6 +18,7 @@ if($MigrationFile.Count -ne 1) { throw 'Error getting migration file';return }
 
 $UpdateSqlFiles = @()
 $SqlStatements = @()
+$SqlDownStatements = @()
 
 $SqlStatementTemplate = @"
 
@@ -45,6 +46,17 @@ Foreach($sqlFile in $SqlFiles){
 
 Foreach($sqlFile in $UpdateSqlFiles){
     $SnapShotFile = ".\Migrations\Sql.Snapshot\$($sqlFile.Directory.Name)\$($sqlFile.Name)"
+    if(Test-Path $SnapShotFile){
+        $SqlContent = Get-Content $SnapShotFile -Raw
+        $SqlContent = $SqlContent.Replace('"','\"')
+        $SqlStatement = $SqlStatementTemplate -f $SqlContent
+        $SqlDownStatements += $SqlStatement
+    }
+    else{
+        $SqlContent = "DROP $($sqlFile.Directory.Name) IF EXISTS $($sqlFile.BaseName)"
+        $SqlStatement = $SqlStatementTemplate -f $SqlContent
+        $SqlDownStatements += $SqlStatement
+    }
     $null = Copy-Item $sqlFile.FullName $SnapShotFile -Force
     $SqlContent = Get-Content $SnapShotFile -Raw
     $SqlContent = $SqlContent.Replace('"','\"')
@@ -64,12 +76,17 @@ Foreach($sqlFile in $SqlFiles){
 }
 
 $InsertString = ""
+$DownString = ""
 
 foreach($sqlStatement in $SqlStatements){
     $InsertString += $SqlStatement.Replace("`n","`n            ")
 }
 
-if([string]::IsNullOrEmpty($InsertString)){
+foreach($sqlStatement in $SqlDownStatements){
+    $DownString += $SqlStatement.Replace("`n","`n            ")
+}
+
+if([string]::IsNullOrEmpty($InsertString) -and [string]::IsNullOrEmpty($DownString)){
     Pop-Location
     exit    
 }
@@ -77,11 +94,18 @@ if([string]::IsNullOrEmpty($InsertString)){
 $MigrationFileContentArray = Get-Content $MigrationFile.FullName
 $MigrationFileContent = ""
 $inserted = $false
+$insertedDown = $false
 for ($i = 0; $i -lt $MigrationFileContentArray.Count; $i++) {
     if(-not [string]::IsNullOrEmpty($MigrationFileContentArray[$i]) -and $inserted -eq $false ){
         if($MigrationFileContentArray[$i].Trim() -eq '}' -and $MigrationFileContentArray[$i + 2].ToLower().Contains('protected override void down(migrationbuilder migrationbuilder)')){
             $MigrationFileContent += "$($InsertString)$([System.Environment]::NewLine)"
             $inserted = $true
+        }
+    }
+    if(-not [string]::IsNullOrEmpty($MigrationFileContentArray[$i - 2]) -and $insertedDown -eq $false ){
+        if($MigrationFileContentArray[$i - 2].Trim() -eq 'protected override void Down(MigrationBuilder migrationBuilder)'){
+            $MigrationFileContent += "$($DownString)$([System.Environment]::NewLine)"
+            $insertedDown = $true
         }
     }
     $MigrationFileContent += "$($MigrationFileContentArray[$i])$([System.Environment]::NewLine)"

--- a/src/EphIt/Classlibraries/EphIt.Db/Migrations/20201128232052_Initial.cs
+++ b/src/EphIt/Classlibraries/EphIt.Db/Migrations/20201128232052_Initial.cs
@@ -683,6 +683,14 @@ namespace EphIt.Db.Migrations
 
         protected override void Down(MigrationBuilder migrationBuilder)
         {
+            migrationBuilder.Sql(@"
+                DROP TRIGGER IF EXISTS TR_Script_Audit_Update
+            ");
+            
+            migrationBuilder.Sql(@"
+                DROP TRIGGER IF EXISTS TR_Script_Audit_Insert
+            ");
+
             migrationBuilder.DropTable(
                 name: "Audit");
 

--- a/src/EphIt/Classlibraries/EphIt.Db/Migrations/20201212195904_RoleAuditTriggers.Designer.cs
+++ b/src/EphIt/Classlibraries/EphIt.Db/Migrations/20201212195904_RoleAuditTriggers.Designer.cs
@@ -4,14 +4,16 @@ using EphIt.Db.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace EphIt.Db.Migrations
 {
     [DbContext(typeof(EphItContext))]
-    partial class EphItContextModelSnapshot : ModelSnapshot
+    [Migration("20201212195904_RoleAuditTriggers")]
+    partial class RoleAuditTriggers
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/EphIt/Classlibraries/EphIt.Db/Migrations/20201212195904_RoleAuditTriggers.cs
+++ b/src/EphIt/Classlibraries/EphIt.Db/Migrations/20201212195904_RoleAuditTriggers.cs
@@ -1,0 +1,71 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace EphIt.Db.Migrations
+{
+    public partial class RoleAuditTriggers : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+
+            migrationBuilder.Sql(@"
+            
+            CREATE OR ALTER TRIGGER dbo.TR_Role_Audit_Insert
+            ON [Role]
+            AFTER INSERT
+            AS BEGIN
+            
+            INSERT INTO [AUDIT] ( RbacActionId, RbacObjectId, Created, UserId, ObjectId )
+            	SELECT
+            		1 AS 'RbacActionId'
+            		,2 AS 'RbacObjectId'
+            		,GETUTCDATE() AS Created
+            		,INSERTED.CreatedByUserId AS UserId
+            		,INSERTED.RoleId AS ObjectId
+            	FROM INSERTED
+            END
+            
+            
+            ");
+            migrationBuilder.Sql(@"
+            
+            CREATE OR ALTER TRIGGER dbo.TR_Role_Audit_Update
+            ON [Role]
+            AFTER UPDATE
+            AS BEGIN
+            
+            INSERT INTO [AUDIT] ( RbacActionId, RbacObjectId, Created, UserId, ObjectId )
+            	SELECT
+            		CASE
+            			WHEN INSERTED.IsDeleted = 1 THEN 3
+            			ELSE 4
+            		END AS 'RbacActionId'
+            		,2 AS 'RbacObjectId'
+            		,GETUTCDATE() AS Created
+            		,INSERTED.ModifiedByUserId AS UserId
+            		,INSERTED.RoleId AS ObjectId
+            	FROM INSERTED
+            END
+            
+            
+            ");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+            migrationBuilder.Sql(@"
+            
+            DROP Trigger IF EXISTS TR_Role_Audit_Insert
+            
+            ");
+            migrationBuilder.Sql(@"
+            
+            DROP Trigger IF EXISTS TR_Role_Audit_Update
+            
+            ");
+
+        }
+    }
+}
+

--- a/src/EphIt/Classlibraries/EphIt.Db/Migrations/Sql.Snapshot/Trigger/TR_Role_Audit_Insert.sql
+++ b/src/EphIt/Classlibraries/EphIt.Db/Migrations/Sql.Snapshot/Trigger/TR_Role_Audit_Insert.sql
@@ -1,0 +1,14 @@
+CREATE OR ALTER TRIGGER dbo.TR_Role_Audit_Insert
+ON [Role]
+AFTER INSERT
+AS BEGIN
+
+INSERT INTO [AUDIT] ( RbacActionId, RbacObjectId, Created, UserId, ObjectId )
+	SELECT
+		1 AS 'RbacActionId'
+		,2 AS 'RbacObjectId'
+		,GETUTCDATE() AS Created
+		,INSERTED.CreatedByUserId AS UserId
+		,INSERTED.RoleIdId AS ObjectId
+	FROM INSERTED
+END

--- a/src/EphIt/Classlibraries/EphIt.Db/Migrations/Sql.Snapshot/Trigger/TR_Role_Audit_Update.sql
+++ b/src/EphIt/Classlibraries/EphIt.Db/Migrations/Sql.Snapshot/Trigger/TR_Role_Audit_Update.sql
@@ -1,0 +1,17 @@
+CREATE OR ALTER TRIGGER dbo.TR_Role_Audit_Update
+ON [Role]
+AFTER UPDATE
+AS BEGIN
+
+INSERT INTO [AUDIT] ( RbacActionId, RbacObjectId, Created, UserId, ObjectId )
+	SELECT
+		CASE
+			WHEN INSERTED.IsDeleted = 1 THEN 3
+			ELSE 4
+		END AS 'RbacActionId'
+		,2 AS 'RbacObjectId'
+		,GETUTCDATE() AS Created
+		,INSERTED.ModifiedByUserId AS UserId
+		,INSERTED.RoleId AS ObjectId
+	FROM INSERTED
+END

--- a/src/EphIt/Classlibraries/EphIt.Db/SQL/Trigger/TR_Role_Audit_Insert.sql
+++ b/src/EphIt/Classlibraries/EphIt.Db/SQL/Trigger/TR_Role_Audit_Insert.sql
@@ -1,0 +1,14 @@
+CREATE OR ALTER TRIGGER dbo.TR_Role_Audit_Insert
+ON [Role]
+AFTER INSERT
+AS BEGIN
+
+INSERT INTO [AUDIT] ( RbacActionId, RbacObjectId, Created, UserId, ObjectId )
+	SELECT
+		1 AS 'RbacActionId'
+		,2 AS 'RbacObjectId'
+		,GETUTCDATE() AS Created
+		,INSERTED.CreatedByUserId AS UserId
+		,INSERTED.RoleId AS ObjectId
+	FROM INSERTED
+END

--- a/src/EphIt/Classlibraries/EphIt.Db/SQL/Trigger/TR_Role_Audit_Update.sql
+++ b/src/EphIt/Classlibraries/EphIt.Db/SQL/Trigger/TR_Role_Audit_Update.sql
@@ -1,0 +1,17 @@
+CREATE OR ALTER TRIGGER dbo.TR_Role_Audit_Update
+ON [Role]
+AFTER UPDATE
+AS BEGIN
+
+INSERT INTO [AUDIT] ( RbacActionId, RbacObjectId, Created, UserId, ObjectId )
+	SELECT
+		CASE
+			WHEN INSERTED.IsDeleted = 1 THEN 3
+			ELSE 4
+		END AS 'RbacActionId'
+		,2 AS 'RbacObjectId'
+		,GETUTCDATE() AS Created
+		,INSERTED.ModifiedByUserId AS UserId
+		,INSERTED.RoleId AS ObjectId
+	FROM INSERTED
+END


### PR DESCRIPTION
This PR does a few things:

1) Adds "down" SQL scripts for views / triggers / other things so up and down all works.
1) Adds audits to Roles
1) Fixes initial migration so the down works

Also, this should be good for auditing *all* Role tables and all Script tables. As long as we do this process to edit the other role tables (like adding members to a role in the table RoleMembershipUser:

1) Edit the Role object and update last modified date and last modified user
2) This will trigger the audit saying the role was modified
3) Then edit the table RoleMembershipUser with the members

Triggers won't be needed for every table, just the main tables for each category of objects.