### PR TITLE
Adding OData

### DIFF
--- a/src/EphIt/EphIt.Server/Controllers/JobController.cs
+++ b/src/EphIt/EphIt.Server/Controllers/JobController.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using System.Collections;
 using Newtonsoft.Json;
+using Microsoft.AspNet.OData;
 
 namespace EphIt.Server.Controllers
 {
@@ -45,6 +46,12 @@ namespace EphIt.Server.Controllers
                 return _jobManager.QueueJob(ver, postParams.Parameters, _ephItUser.Register().UserId, postParams.ScheduleID, postParams.AutomationID);
             }
             return null;
+        }
+        [HttpGet]
+        [EnableQuery]
+        public IEnumerable<Job> Get()
+        {
+            return _dbContext.Job;
         }
         [HttpGet]
         [Route("/api/[controller]/Queued")]

--- a/src/EphIt/EphIt.Server/Controllers/ScriptController.cs
+++ b/src/EphIt/EphIt.Server/Controllers/ScriptController.cs
@@ -6,6 +6,7 @@ using EphIt.BL.Authorization;
 using EphIt.BL.Script;
 using EphIt.BL.User;
 using EphIt.Db.Models;
+using Microsoft.AspNet.OData;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -39,6 +40,12 @@ namespace EphIt.Server.Controllers
             }
 
             return item;
+        }
+        [HttpGet]
+        [EnableQuery]
+        public IEnumerable<Script> Get()
+        {
+            return _dbContext.Script;
         }
         [HttpGet]
         [Route("/api/[controller]")]

--- a/src/EphIt/EphIt.Server/EphIt.Server.csproj
+++ b/src/EphIt/EphIt.Server/EphIt.Server.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.9" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="3.2.1" />
+    <PackageReference Include="Microsoft.AspNetCore.OData" Version="7.5.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.3">
       <PrivateAssets>all</PrivateAssets>

--- a/src/EphIt/EphIt.Server/Properties/launchSettings.json
+++ b/src/EphIt/EphIt.Server/Properties/launchSettings.json
@@ -13,7 +13,7 @@
       "launchBrowser": true,
       "launchUrl": "http://localhost:60904/api/script",
       "environmentVariables": {
-        "ASPNETCORE_DROPDB": "True",
+        "ASPNETCORE_DROPDB": "False",
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
       "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}"

--- a/src/EphIt/EphIt.Server/Startup.cs
+++ b/src/EphIt/EphIt.Server/Startup.cs
@@ -21,6 +21,9 @@ using Microsoft.AspNetCore.Server.IIS;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using EphIt.BL.JobManager;
 using System.Collections.Generic;
+using Microsoft.AspNet.OData.Extensions;
+using Microsoft.OData.Edm;
+using Microsoft.AspNet.OData.Builder;
 
 namespace EphIt.Blazor.Server
 {
@@ -51,6 +54,7 @@ namespace EphIt.Blazor.Server
 
             services.AddControllersWithViews();
             services.AddRazorPages();
+            services.AddOData();
             services.AddDbContext<EphItContext>(
                     options => 
                         options.UseSqlServer(Configuration.GetConnectionString("EphItDb"))
@@ -115,7 +119,16 @@ namespace EphIt.Blazor.Server
                 endpoints.MapRazorPages();
                 endpoints.MapControllers();
                 endpoints.MapFallbackToFile("index.html");
+                endpoints.Select().Filter().OrderBy().Count().MaxTop(10);
+                endpoints.MapODataRoute("api", "api", GetEdmModel());
             });
+        }
+        private IEdmModel GetEdmModel()
+        {
+            var odataBuilder = new ODataConventionModelBuilder();
+            odataBuilder.EntitySet<Script>("Script");
+            odataBuilder.EntitySet<Job>("Job");
+            return odataBuilder.GetEdmModel();
         }
         public void ConfigureDb(IEphItUser user, EphItContext _context)
         {


### PR DESCRIPTION
Adding Microsoft.AspNetCore.OData to the project and enabled it for Script and Job controllers.  Now we can query:

/api/Script
/api/Job

and pass in common OData queries to filter correctly. 

This *currently* does not follow RBAC but I have an idea for how to make it work. Instead of directly calling the Script table, I'll call a virtual table called RBACScript (or something similar) that is generated using this FromSql:

Select * from Script where ScriptId in ( Select ScriptId from v_RBACScript where UserId = <InsertCurrentUserId> )

Then RBAC is respected and we can still use this sweet OData stuff.